### PR TITLE
fix: CSS Loader for external CSS Libs

### DIFF
--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -3,28 +3,48 @@ const path = require('path')
 const extra = require('../webpack.extra.js')
 
 module.exports = (baseConfig, env, defaultConfig) => {
-  const cssRule = {
-    test: /\.css$/,
-    use: [
-      {
-        loader: 'style-loader',
-      },
-      {
-        loader: 'css-loader',
-        options: {
-          modules: true,
+  const cssRules = [
+    {
+      test: /\.css$/,
+      exclude: /node_modules/,
+      use: [
+        {
+          loader: 'style-loader',
         },
-      },
-      {
-        loader: 'postcss-loader',
-        options: {
-          config: {
-            path: path.resolve(process.cwd()),
+        {
+          loader: 'css-loader',
+          options: {
+            modules: true,
           },
         },
-      },
-    ],
-  }
+        {
+          loader: 'postcss-loader',
+          options: {
+            config: {
+              path: path.resolve(process.cwd()),
+            },
+          },
+        },
+      ],
+    },
+    {
+      test: /\.css$/,
+      include: /node_modules/,
+      use: [
+        {
+          loader: 'style-loader',
+        },
+        {
+          loader: 'css-loader',
+          options: {
+            modules: false,
+          },
+        },
+      ],
+    },
+  ]
+  const rules = defaultConfig.module.rules.map(rule => !rule.test.test('.css'))
+
   const config = {
     ...defaultConfig,
     resolve: {
@@ -33,7 +53,10 @@ module.exports = (baseConfig, env, defaultConfig) => {
     },
     module: {
       ...defaultConfig.module,
-      rules: defaultConfig.module.rules.map(rule => (rule.test.test('.css') ? cssRule : rule)),
+      rules: {
+        ...rules,
+        ...cssRules,
+      },
     },
   }
 


### PR DESCRIPTION
## Bug Fix

This PR relates to the #40, where are described as a bug with CSS into `Storybook`.

With the help of @dleitee, we managed to resolve the issue with just adding `exclude` rule to CSS that are being handled from `node_modules/`.

This is the page working: 
![image](https://user-images.githubusercontent.com/7551787/54163496-fa9d1780-4437-11e9-8ce6-893a6dbdcd45.png)
